### PR TITLE
fix:Setting useNativeDriver to false causes the pop-up position to shift to the right after the animation ends

### DIFF
--- a/index.js
+++ b/index.js
@@ -487,7 +487,6 @@ export default class ModalBox extends React.PureComponent {
       height: this.state.containerHeight,
       width: this.state.containerWidth
     };
-    const offsetX = (this.state.containerWidth - this.state.width) / 2;
 
     return (
       <Animated.View
@@ -497,9 +496,9 @@ export default class ModalBox extends React.PureComponent {
           size,
           this.props.style,
           {
+            alignSelf: 'center',
             transform: [
-              {translateY: this.state.position},
-              {translateX: offsetX}
+              {translateY: this.state.position}
             ]
           }
         ]}


### PR DESCRIPTION
fix:Setting useNativeDriver to false causes the pop-up position to shift to the right after the animation ends

修改了modalbox设置useNativeDriver=false时，弹出动画结束后弹框向右偏移的问题